### PR TITLE
Trim one leading zero from 4-digit clearing numbers

### DIFF
--- a/src/SwedishBankAccountNumber/ClearingNumber.elm
+++ b/src/SwedishBankAccountNumber/ClearingNumber.elm
@@ -103,7 +103,6 @@ fromString string =
     let
         digits =
             String.filter Char.isDigit string
-                |> trimLeadingZeroes
 
         numDigits =
             String.length digits
@@ -121,7 +120,7 @@ fromString string =
                 Just bank ->
                     Ok
                         ( convertCategory (Bank.getCategory bank)
-                        , ClearingNumber bank digits
+                        , ClearingNumber bank (String.fromInt clearing)
                         )
 
                 Nothing ->
@@ -129,15 +128,6 @@ fromString string =
 
         Nothing ->
             Err (BadLength numDigits)
-
-
-trimLeadingZeroes : String -> String
-trimLeadingZeroes string =
-    if String.startsWith "0" string then
-        trimLeadingZeroes (String.dropLeft 1 string)
-
-    else
-        string
 
 
 {-| Get a string containing digits only (no hyphens or spaces or anything),

--- a/src/SwedishBankAccountNumber/ClearingNumber.elm
+++ b/src/SwedishBankAccountNumber/ClearingNumber.elm
@@ -103,6 +103,7 @@ fromString string =
     let
         digits =
             String.filter Char.isDigit string
+                |> trimLeadingZeroes
 
         numDigits =
             String.length digits
@@ -128,6 +129,15 @@ fromString string =
 
         Nothing ->
             Err (BadLength numDigits)
+
+
+trimLeadingZeroes : String -> String
+trimLeadingZeroes string =
+    if String.startsWith "0" string then
+        trimLeadingZeroes (String.dropLeft 1 string)
+
+    else
+        string
 
 
 {-| Get a string containing digits only (no hyphens or spaces or anything),

--- a/tests/SwedishBankAccountNumberTest.elm
+++ b/tests/SwedishBankAccountNumberTest.elm
@@ -84,6 +84,17 @@ bankSuite =
                             , accountNumber = "4172385"
                             }
                         )
+        , test "Leading zeroes in account number (but not clearing number) should be preserved" <|
+            \_ ->
+                validate "09420" ", 000 23 88"
+                    |> Result.map SwedishBankAccountNumber.toRecord
+                    |> Expect.equal
+                        (Ok
+                            { bankName = "Forex Bank"
+                            , clearingNumber = "9420"
+                            , accountNumber = "0002388"
+                            }
+                        )
         , test "Handelsbanken" <|
             \_ ->
                 validate "6789" "123456789"
@@ -177,6 +188,11 @@ clearingNumberSuite =
         , test "toString" <|
             \_ ->
                 SwedishBankAccountNumber.ClearingNumber.fromString " 96 61-"
+                    |> Result.map (Tuple.second >> SwedishBankAccountNumber.ClearingNumber.toString)
+                    |> Expect.equal (Ok "9661")
+        , test "remove leading zeroes" <|
+            \_ ->
+                SwedishBankAccountNumber.ClearingNumber.fromString " 00- 096 61"
                     |> Result.map (Tuple.second >> SwedishBankAccountNumber.ClearingNumber.toString)
                     |> Expect.equal (Ok "9661")
         , test "getBankName" <|

--- a/tests/SwedishBankAccountNumberTest.elm
+++ b/tests/SwedishBankAccountNumberTest.elm
@@ -176,9 +176,17 @@ clearingNumberSuite =
                 \_ ->
                     SwedishBankAccountNumber.ClearingNumber.fromString "123456"
                         |> Expect.equal (Err (SwedishBankAccountNumber.ClearingNumber.BadLength 6))
+            , test "Too long due to leading zeroes" <|
+                \_ ->
+                    SwedishBankAccountNumber.ClearingNumber.fromString "001234"
+                        |> Expect.equal (Err (SwedishBankAccountNumber.ClearingNumber.BadLength 6))
             , test "Unknown" <|
                 \_ ->
                     SwedishBankAccountNumber.ClearingNumber.fromString "9999"
+                        |> Expect.equal (Err SwedishBankAccountNumber.ClearingNumber.Unknown)
+            , test "Unknown with leading zeroes" <|
+                \_ ->
+                    SwedishBankAccountNumber.ClearingNumber.fromString "0099"
                         |> Expect.equal (Err SwedishBankAccountNumber.ClearingNumber.Unknown)
             , test "Unknown Swedbank" <|
                 \_ ->
@@ -190,9 +198,9 @@ clearingNumberSuite =
                 SwedishBankAccountNumber.ClearingNumber.fromString " 96 61-"
                     |> Result.map (Tuple.second >> SwedishBankAccountNumber.ClearingNumber.toString)
                     |> Expect.equal (Ok "9661")
-        , test "remove leading zeroes" <|
+        , test "Remove one leading zero" <|
             \_ ->
-                SwedishBankAccountNumber.ClearingNumber.fromString " 00- 096 61"
+                SwedishBankAccountNumber.ClearingNumber.fromString " 0- 96 61"
                     |> Result.map (Tuple.second >> SwedishBankAccountNumber.ClearingNumber.toString)
                     |> Expect.equal (Ok "9661")
         , test "getBankName" <|


### PR DESCRIPTION
At Insurello, a customer added a leading zero in front of their 4-digit clearing number. The code accidentally accepts that (due to the special case where Swedbank sometimes have 5-digit clearing number). But a leading zero is not valid.

This PR still requires 4-5 digits, but removes the one possible leading zero for 4-digit clearing numbers. We do that instead of giving an error, because the instructions for the clearing number typically say “4-5 digits” and a number like `01234` _is_ 5 digits and feels valid to a human.

Note that clearing numbers never start with a 0.